### PR TITLE
update install script

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,13 +5,12 @@ package:
   version: {{ version }}
 
 source:
-  fn: jupyter_core-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/j/jupyter_core/jupyter_core-{{ version }}.tar.gz
   sha256: ba70754aa680300306c699790128f6fbd8c306ee5927976cbe48adacf240c0b7
 
 build:
   number: 0
-  script: pip install --no-deps .
+  script: python -m pip install --no-deps --ignore-installed .
   noarch: python
   entry_points:
     - jupyter = jupyter_core.command:main


### PR DESCRIPTION
@minrk this one is already `noarch`. If my memory is correct I guess we are OK on Windows as long as we specify the entrypoints in the recipe.