### PR TITLE
[ci skip] adding user @blink1073

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Carreau @bollwyvl @jakirkham @jasongrout @minrk @ocefpaf @pelson
+* @blink1073 @Carreau @bollwyvl @jakirkham @jasongrout @minrk @ocefpaf @pelson

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,6 +62,7 @@ about:
 
 extra:
   recipe-maintainers:
+    - blink1073
     - jakirkham
     - pelson
     - minrk


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @blink1073 as instructed in #45.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Please contact [conda-forge/core](https://conda-forge.org/docs/maintainer/maintainer_faq.html#mfaq-contact-core) to have this PR merged, if the maintainer is unresponsive.

Fixes #45