### PR TITLE
jupyter_core 5.1.0, use github release tarball

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -12,3 +12,5 @@ provider:
 test_on_native_only: true
 conda_build:
   pkg_format: '2'
+abi_migration_branches:
+  - 4.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,8 +5,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/j/jupyter_core/jupyter_core-{{ version }}.tar.gz
-  sha256: 4ed68b7c606197c7e344a24b7195eef57898157075a69655a886074b6beb7043
+  url: https://github.com/jupyter/jupyter_core/releases/download/v{{ version }}/jupyter_core-{{ version }}.tar.gz
+  sha256: a5ae7c09c55c0b26f692ec69323ba2b62e8d7295354d20f6cd57b749de4a05bf
 
 build:
   number: 0
@@ -26,10 +26,10 @@ requirements:
     - python
     - hatchling >=1.4
   run:
-    - platformdirs
+    - platformdirs >=2.5
     - python
     - pywin32 >=1.0  # [win and python_impl != 'pypy']
-    - traitlets
+    - traitlets >=5.3
 
 {% set skip = ["test_not_on_path", "test_path_priority"] %}
 # linux shebang lines have a length limit longer than the placeholder test prefix


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Notes:
- starts #57 
- uses github release tarball
  - which provides a build-time captured sha, so unlikely to change due to github shenangans
    - also matches what ends up on pypi :tada: 
- adds `4.x` to `abi_migration_branches`
  -  see #59